### PR TITLE
패키지 구조 확정 및 변경

### DIFF
--- a/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleApi.java
+++ b/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleApi.java
@@ -1,4 +1,4 @@
-package hongik.burgerq.swaggerdemo;
+package hongik.burgerq.common.apiDocs.swaggerdemo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
 public interface SampleApi {
 	@Operation(summary = "샘플 API 입니다.")

--- a/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleController.java
+++ b/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleController.java
@@ -1,4 +1,4 @@
-package hongik.burgerq.swaggerdemo;
+package hongik.burgerq.common.apiDocs.swaggerdemo;
 
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleErrorResponse.java
+++ b/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleErrorResponse.java
@@ -1,4 +1,4 @@
-package hongik.burgerq.swaggerdemo;
+package hongik.burgerq.common.apiDocs.swaggerdemo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleRequest.java
+++ b/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleRequest.java
@@ -1,4 +1,4 @@
-package hongik.burgerq.swaggerdemo;
+package hongik.burgerq.common.apiDocs.swaggerdemo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleResponse.java
+++ b/src/main/java/hongik/burgerq/common/apiDocs/swaggerdemo/SampleResponse.java
@@ -1,4 +1,4 @@
-package hongik.burgerq.swaggerdemo;
+package hongik.burgerq.common.apiDocs.swaggerdemo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;


### PR DESCRIPTION
> ### How
- 스프링 스터디의 레이어드 아키텍쳐 챕터의 내용을 통해 패키지 구조를 확정지었습니다.
- 도메인 중심 분리가 아닌 레이어 중심 분리를 택했습니다.

> ### Result
<img width="279" alt="스크린샷 2024-09-20 오후 6 17 24" src="https://github.com/user-attachments/assets/68a991cf-b3a9-4ba4-a584-2fba43a3f5e9">